### PR TITLE
Add autosuggest variants

### DIFF
--- a/Data/SearchEngine.hs
+++ b/Data/SearchEngine.hs
@@ -9,6 +9,8 @@ module Data.SearchEngine (
     -- *** Query auto-completion \/ auto-suggestion
     queryAutosuggest,
     ResultsFilter(..),
+    queryAutosuggestPredicate,
+    queryAutosuggestMatchingDocuments,
 
     -- ** Making a search engine instance
     initSearchEngine,

--- a/Data/SearchEngine/DocIdSet.hs
+++ b/Data/SearchEngine/DocIdSet.hs
@@ -11,6 +11,7 @@ module Data.SearchEngine.DocIdSet (
     toList,
     insert,
     delete,
+    member,
     union,
     unions,
     intersection,
@@ -79,6 +80,9 @@ delete x (DocIdSet vec) =
       (i, True)  -> case Vec.splitAt i vec of
                       (before, after) ->
                         DocIdSet (before Vec.++ Vec.tail after)
+
+member :: DocId -> DocIdSet -> Bool
+member x (DocIdSet vec) = snd (binarySearch vec 0 (Vec.length vec - 1) x)
 
 binarySearch :: Vec.Vector DocId -> Int -> Int -> DocId -> (Int, Bool)
 binarySearch vec !a !b !key

--- a/Data/SearchEngine/SearchIndex.hs
+++ b/Data/SearchEngine/SearchIndex.hs
@@ -16,6 +16,7 @@ module Data.SearchEngine.SearchIndex (
     lookupTermId,
     lookupDocId,
     lookupDocKey,
+    lookupDocKeyDocId,
 
     getTerm,
     getDocKey,
@@ -192,6 +193,9 @@ lookupDocKey SearchIndex{docKeyMap, docIdMap} key = do
         case IntMap.lookup (fromEnum docid) docIdMap of
           Nothing                          -> error "lookupDocKey: internal error"
           Just (DocInfo _key doctermids _) -> Just doctermids
+
+lookupDocKeyDocId :: Ord key => SearchIndex key field feature -> key -> Maybe DocId
+lookupDocKeyDocId SearchIndex{docKeyMap} key = Map.lookup key docKeyMap
 
 
 getTerm :: SearchIndex key field feature -> TermId -> Term

--- a/full-text-search.cabal
+++ b/full-text-search.cabal
@@ -131,6 +131,7 @@ test-suite qc-props
   other-modules:       Test.Data.SearchEngine.TermBag,
                        Test.Data.SearchEngine.DocIdSet,
                        Data.SearchEngine.DocTermIds,
-                       Data.SearchEngine.DocIdSet
+                       Data.SearchEngine.DocIdSet,
+                       Data.SearchEngine.TermBag
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/tests/Test/Data/SearchEngine/DocIdSet.hs
+++ b/tests/Test/Data/SearchEngine/DocIdSet.hs
@@ -1,7 +1,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Data.SearchEngine.DocIdSet where
 
-import Data.SearchEngine.DocIdSet
+import Data.SearchEngine.DocIdSet (DocIdSet(DocIdSet), DocId(DocId))
+import qualified Data.SearchEngine.DocIdSet as DocIdSet
 
 import qualified Data.Vector.Unboxed as Vec
 import qualified Data.List as List
@@ -9,7 +10,7 @@ import Test.QuickCheck
 
 
 instance Arbitrary DocIdSet where
-  arbitrary = fromList `fmap` (listOf arbitrary)
+  arbitrary = DocIdSet.fromList `fmap` (listOf arbitrary)
 
 instance Arbitrary DocId where
   arbitrary = DocId `fmap` choose (0,15)
@@ -17,35 +18,35 @@ instance Arbitrary DocId where
 
 prop_insert :: DocIdSet -> DocId -> Bool
 prop_insert dset x =
-    let dset' = insert x dset
-     in invariant dset && invariant dset'
-     && all (`member` dset') (x : toList dset)
+    let dset' = DocIdSet.insert x dset
+     in DocIdSet.invariant dset && DocIdSet.invariant dset'
+     && all (`member` dset') (x : DocIdSet.toList dset)
 
 prop_delete :: DocIdSet -> DocId -> Bool
 prop_delete dset x =
-    let dset' = delete x dset
-     in invariant dset && invariant dset'
-     && all (`member` dset') (List.delete x (toList dset))
+    let dset' = DocIdSet.delete x dset
+     in DocIdSet.invariant dset && DocIdSet.invariant dset'
+     && all (`member` dset') (List.delete x (DocIdSet.toList dset))
      && not (x `member` dset')
 
 prop_delete' :: DocIdSet -> Bool
 prop_delete' dset =
-    all (prop_delete dset) (toList dset)
+    all (prop_delete dset) (DocIdSet.toList dset)
 
 prop_union :: DocIdSet -> DocIdSet -> Bool
 prop_union dset1 dset2 =
-    let dset  = union dset1 dset2
-        dset' = fromList (List.union (toList dset1) (toList dset2))
+    let dset  = DocIdSet.union dset1 dset2
+        dset' = DocIdSet.fromList (List.union (DocIdSet.toList dset1) (DocIdSet.toList dset2))
 
-     in invariant dset && invariant dset'
+     in DocIdSet.invariant dset && DocIdSet.invariant dset'
      && dset == dset'
 
 prop_union' :: DocIdSet -> DocIdSet -> Bool
 prop_union' dset1 dset2 =
-    let dset   = union dset1 dset2
-        dset'  = List.foldl' (\s i -> insert i s) dset1 (toList dset2)
-        dset'' = List.foldl' (\s i -> insert i s) dset2 (toList dset1)
-     in invariant dset && invariant dset' && invariant dset''
+    let dset   = DocIdSet.union dset1 dset2
+        dset'  = List.foldl' (\s i -> DocIdSet.insert i s) dset1 (DocIdSet.toList dset2)
+        dset'' = List.foldl' (\s i -> DocIdSet.insert i s) dset2 (DocIdSet.toList dset1)
+     in DocIdSet.invariant dset && DocIdSet.invariant dset' && DocIdSet.invariant dset''
      && dset == dset'
      && dset' == dset''
 


### PR DESCRIPTION
This adds a couple of functions based on part of `queryAutosuggest`, which are useful when you want to find the set of documents matching a query without doing any ranking.